### PR TITLE
Fix ruby error when ghost inspector results are not returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Google Analytics uses Custom Dimensions as outlined in the [Google Measurement P
 git commit -am "GHOST-123 Add new item to the gem"
 ```
 
+## Waiting for results
+
+When both `ga_enabled` and `rollback` are set to false then the tests are executed but the results are not returned and taken in to account.
+
 ## Usage
 
 Run a particular test when deploying to staging -

--- a/lib/capistrano/ghostinspector.rb
+++ b/lib/capistrano/ghostinspector.rb
@@ -86,7 +86,11 @@ module Capistrano
                 set :data, giApi.executeApi("suites", suite)
 
                 data[1]["data"].each do |test|
-                  items = { :passing => test["passing"], :results => test, :type =>  "suites"}
+                  items = {
+                    :passing => giApi.shouldWaitForResults() ? true : test["passing"],
+                    :results => test,
+                    :type =>  "suites"
+                  }
                   @collection << items
                 end
 

--- a/lib/capistrano/ghostinspector/api.rb
+++ b/lib/capistrano/ghostinspector/api.rb
@@ -43,13 +43,17 @@ module Capistrano
 
       end
 
+      def shouldWaitForResults()
+        return @rollback == false && @ga_enabled == false;
+      end
+
       private
 
       def includeResults()
 
         # Determine if we should get results to
         # check for any failed tests
-        if (@rollback == false && @ga_enabled == false)
+        if (shouldWaitForResults())
           immediate = "&immediate=1"
         else
           immediate = ""


### PR DESCRIPTION
When `ga_enabled` and `rollback` are set to false then passing is nil
this in turn causes the following error:
`[]': no implicit conversion of String into Integer (TypeError)